### PR TITLE
Profiles - Add load profile message, double click profile to load

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,20 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            // Default build task, press Ctrl+Shift+B to build dev version and launch
+            "label": "HEMTT Launch",
+            "command": "hemtt.exe",
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "args": [
+                "launch"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}

--- a/addons/profiles/functions/fnc_buttonLoadProfile.sqf
+++ b/addons/profiles/functions/fnc_buttonLoadProfile.sqf
@@ -25,4 +25,6 @@ private _profileName = _contentPanel lbText (lbCurSel _contentPanel);
 
 [_profileName, true] call FUNC(loadProfile);
 
+format [LLSTRING(loadedProfile), _profileName] call FUNC(message);
+
 true; // Keep display open

--- a/addons/profiles/gui.hpp
+++ b/addons/profiles/gui.hpp
@@ -42,6 +42,7 @@ class GVAR(display) {
                     h = QUOTE(HEIGHT_TOTAL);
                     colorBackground[] = {0.13, 0.13, 0.13, 0.9};
                     sizeEx = QUOTE(TEXT_SIZE * GRID_H);
+                    onLBDblClick = QUOTE([ARR_2(ctrlParent (_this select 0),_this select 0)] call FUNC(buttonLoadProfile));
                 };
                 class buttonClose: ctrlButton {
                     idc = -1;

--- a/addons/profiles/script_component.hpp
+++ b/addons/profiles/script_component.hpp
@@ -2,7 +2,7 @@
 #define COMPONENT_BEAUTIFIED Profiles
 #include "\z\trp\addons\main\script_mod.hpp"
 
-#define DEBUG_MODE_FULL
+// #define DEBUG_MODE_FULL
 // #define DISABLE_COMPILE_CACHE
 // #define ENABLE_PERFORMANCE_COUNTERS
 

--- a/addons/profiles/stringtable.xml
+++ b/addons/profiles/stringtable.xml
@@ -75,6 +75,9 @@
         <Key ID="STR_trp_profiles_emptyNameError">
             <English>The profile's name cannot be empty.</English>
         </Key>
+        <Key ID="STR_trp_profiles_loadedProfile">
+            <English>Loaded Profile: %1</English>
+        </Key>
         <Key ID="STR_trp_profiles_openRadioProfiles_name">
             <English>Open Radio Profile Menu</English>
         </Key>


### PR DESCRIPTION
**When merged this pull request will:**
- Add build task for `hemtt launch`
- Add a message when a profile is loaded
- Double clicking a profile now loads the profile

### Important
- [x] If the contribution affects [the documentation](../docs), please include your changes in this pull request.
- [x] [Development Guidelines](https://github.com/DartsArmaMods/TFARRadioProfiles/blob/main/.github/CONTRIBUTING.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.

<!-- Known issues that need to be addressed -->
### Known Issues
- None